### PR TITLE
Added blog

### DIFF
--- a/_blog/005_welcome.md
+++ b/_blog/005_welcome.md
@@ -1,0 +1,12 @@
+---
+title: JabRef Blog
+id: welcome
+bg: jabref-font
+color: white
+style: left
+---
+
+#Welcome to the JabRef blog!
+
+This is the blog website of JabRef. Any developer or user can write and publish blog posts on this website. To do so you need to go to <https://github.com/JabRef/www.jabref.org> and fork the repository. Then you create a new branch on your fork with the name of the subject you want to write about. Write your blog post in a markdown file name it with a leading incremented number and copy it into the _blog folder. Add your changes to your git index, commit and push your changes. Finally open a pull request and wait for feedback. Once your changes are merged your blog post will be on top of this site and featured in the news section of the [JabRef](../#news) website.  
+

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ safe: false
 
 ### site serving configuration ###
 exclude: [CNAME, README.md, .gitignore, vendor]
-include: ['surveys/', 'surveys/2015/', 'faq/']
+include: ['surveys/', 'surveys/2015/', 'faq/', 'blog/']
 permalink: /:title ## disables post output
 timezone: null
 lsi: false
@@ -19,9 +19,10 @@ highlighter: rouge
 #redcarpet:
 #  extensions: ["smart", "tables", "no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript", "with_toc_data"]
 
-### required for faq/
+### required for faq/ and blog/
 collections:
 - faq
+- blog
 
 ### content configuration ###
 title:       "JabRef"

--- a/_posts/2004-04-01-news.md
+++ b/_posts/2004-04-01-news.md
@@ -6,7 +6,13 @@ style: left
 fa-icon: star
 ---
 
+## 2016-03-29
+
+* A new blog website for posts about JabRef is now available at [http://www.jabref.org/blog](blog).
+
 ## 2016-01-27
 
  * The results of the survey are available at [http://www.jabref.org/surveys/2015/](surveys/2015/)
  * [JabCon](http://jabcon.jabref.org/) is over and we are working on releasing a new version containing the results of our hacking sessions
+
+##Newest blog post

--- a/blog.css
+++ b/blog.css
@@ -1,0 +1,43 @@
+---
+---
+/* ----- per blog colors! ----- */
+{% for node in site.blog %}
+  {% capture id %}{{ node.id | remove:'/' | downcase }}{% endcapture %}
+  {% capture bg %}{% if site.colors[node.bg] %}{{ site.colors[node.bg] }}{% else %}{{ node.bg }}{% endif %}{% endcapture %}
+  {% capture fg %}{% if site.colors[node.color] %}{{ site.colors[node.color] }}{% else %}{{ node.color }}{% endif %}{% endcapture %}
+  nav .p-{{id}} { border-color: {{ bg }}; }
+  #{{id}} { background-color: {{ bg }} !important; color: {{ fg }}; }
+  #{{id}} a { color: {{ fg }}; }
+  #{{id}} .sectiondivider { color: {{ bg }}; }
+{% endfor %}
+
+/* fix CSS of combo.css */
+
+html body div#main nav {
+  background-color: #4d4674;
+}
+
+.container h2 {
+  font-size: 21px;
+  font-weight: 500;
+  text-align: left;
+  line-height: normal;
+  padding-left: 5%;
+}
+
+.section {
+  padding: 20px;
+}
+
+.editparagraph {
+  padding-top: 5px;position:relative; top:47px; left:740px;
+}
+
+.editlink {
+  text-decoration: none;
+  color: #686868;
+}
+
+code {
+  white-space: pre;
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,56 +1,47 @@
 ---
+title: JabRef Blog
 ---
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ site.title }}</title>
-	<meta name="keywords" content="{{ site.keywords }}">
-	<meta name="description" content="{{ site.description }}">
-  <link rel="stylesheet" href="combo.css">
+  <title>{{ page.title }}</title>
+	<meta name="keywords" content="JabRef Developers Blog, JabRef Blog, Developers Blog">
+	<meta name="description" content="The Developers Blog of JabRef">
+  <link rel="stylesheet" href="../combo.css">
+  <link rel="stylesheet" href="../blog.css">
   <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
   {% if site.favicon %}<link rel="shortcut icon" href="{{ site.favicon }}" type="image/x-icon">{% endif %}
 	{% if site.touch_icon %}<link rel="apple-touch-icon" href="{{ site.touch_icon }}">{% endif %}
 </head>
 <body>
+
+  <div style="position: fixed; left: 10px; top: 10px; z-index: 9999">
+      <a href="../"><i class="fa fa-home fa-2x" style="color:white"></i></a>
+  </div>
+
   <div id="main">
-
+      
     <nav><ul>
-      {% for node in site.posts reversed %}
-        {% capture id %}{{ node.id | remove:'/' | downcase }}{% endcapture %}
-        <li class="p-{{id}}"><a href="#{{id}}">{{node.title}}</a></li>
-      {% endfor %}
+        <li class="p-{{ site.blog.last.id }}"><a href="#{{ site.blog.last.id }}">Top</a></li>
+        <li class="p-welcome"><a href="#welcome">JabRef Blog</a></li>
+        <li class="p-{{ site.blog.first.id }}"><a href="#{{ site.blog.first.id }}">Bottom</a></li>
     </ul></nav>
+    
 
-
-    {% for page in site.posts reversed %}
+    {% for page in site.blog reversed%}
       {% capture id %}{{ page.id | remove:'/' | downcase }}{% endcapture %}
       <div id="{{id}}" class="section p-{{id}}">
-        {% if page.icon %}
-        <div class="subtlecircle sectiondivider imaged">
-          <img src="{{page.icon}}" alt="section icon" />
-          <h5 class="icon-title">{{ page.title }}</h5>
-        </div>
-        {% elsif page.fa-icon %}
-        <div class="subtlecircle sectiondivider faicon">
-          <span class="fa-stack">
-            <i class="fa fa-circle fa-stack-2x"></i>
-            <i class="fa fa-{{ page.fa-icon }} fa-stack-1x"></i>
-          </span>
-          <h5 class="icon-title">{{ page.title }}</h5>
-        </div>
-        {% endif %}
         <div class="container {{ page.style }}">
+          <p class="editparagraph">
+            <a class="editlink" href="{{site.github.repository_url}}/blob/gh-pages/{{page.relative_path}}"><i class="fa fa-pencil fa-1x"></i> View on GitHub</a>
+          </p>
           {{ page.content }}
-          {% if id == "news" %}
-            {{ site.blog.last.content }}
-          {% endif %}
         </div>
       </div>
     {% endfor %}
-
 
     <div id="footer" class="section text-white">
       <div class="container">
@@ -63,5 +54,5 @@
 {% include analytics.html %}
 </body>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-<script src="site.js"></script>
+<script src="../site.js"></script>
 </html>


### PR DESCRIPTION
As requested at #29 

- Blogging functionality added to the jabref website with the url http://www.jabref.org/blog.
- Newest blog post gets automatically displayed in the end of the news section.
- Blog uses same design as http://www.jabref.org and http://www.jabref.org/faq/ and is generally inspired by the faq website in terms of its structure.

New blogs should be added in the _blog folder with a leading number in their name. This way they will automatically appear in the right order on the blog website (newest on the top) and the one with the highest leading number gets featured in the news section.