### PR TITLE
Reversed top and bottom references in menu entry, added id to survey post

### DIFF
--- a/_posts/2016-01-27-JabCon.md
+++ b/_posts/2016-01-27-JabCon.md
@@ -1,5 +1,6 @@
 ---
 title: Survey and JabCon
+id: survey-jabcon
 bg: turquoise
 color: white
 style: left

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,9 +25,9 @@ title: JabRef Blog
   <div id="main">
       
     <nav><ul>
-        <li class="p-{{ site.posts.last.id }}"><a href="#{{ site.posts.last.id }}">Top</a></li>
+        <li class="p-{{ site.posts.first.id }}"><a href="#{{ site.posts.first.id }}">Top</a></li>
         <li class="p-welcome"><a href="#welcome">JabRef Blog</a></li>
-        <li class="p-{{ site.posts.first.id }}"><a href="#{{ site.posts.first.id }}">Bottom</a></li>
+        <li class="p-{{ site.posts.last.id }}"><a href="#{{ site.posts.last.id }}">Bottom</a></li>
     </ul></nav>
     
 


### PR DESCRIPTION
Since you named the files differently the top and bottom menu entries need to get the reversed ids to set the jump reference. Clicking on a menu entry at www.jabref.org/blog/ doesn't invoke scrolling because the post 2016-01-27-JabCon.md doesn't have an id, so I added one.
An alternative is to set the jumping reference depending on the title and not on the id or to remove the menu entries completely.