### PR TITLE
Proposal blogging functionallity filtered by categories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ In case you want to review your change locally, consult [README.md](README.md).
 ## contribute blog posts
 * Copy an existing post in `_posts` and adapt it
 * Put title in quotes (`"..."`) to ensure that the tool is able to process it
+* When adding categories to your post please use the category attribute even when adding multiple categories
 * You can add blog posts appearing in the future
 * Place images in `/img` and refer to them by `![image: SHORTTEXT]({{ site.url }}/img/FILENAME.png)`
 

--- a/_posts/2016-01-26-welcome.md
+++ b/_posts/2016-01-26-welcome.md
@@ -4,6 +4,7 @@ id: welcome
 bg: jabref-font
 color: white
 author: "[JabRef Developers](https://github.com/orgs/JabRef/teams/developers)"
+category: [user, developer]
 ---
 
 This is the blog website of JabRef.

--- a/_posts/2016-01-27-JabCon.md
+++ b/_posts/2016-01-27-JabCon.md
@@ -2,6 +2,7 @@
 title: Survey and JabCon
 id: survey-jabcon
 author: "[JabRef Developers](https://github.com/orgs/JabRef/teams/developers)"
+category: [user, developer]
 ---
 
  * The results of the survey are available at [http://www.jabref.org/surveys/2015/](http://www.jabref.org/surveys/2015/)

--- a/_posts/2016-04-08-FasterJabRef.md
+++ b/_posts/2016-04-08-FasterJabRef.md
@@ -4,6 +4,7 @@ id: faster-jabref
 bg: jabref-font
 color: white
 author: "[mlep](https://github.com/mlep)"
+category: user
 ---
 
 Some users reported JabRef was slow on large databases (thank you for the feedback!).

--- a/_posts/2016-04-19-JabRef3.3.md
+++ b/_posts/2016-04-19-JabRef3.3.md
@@ -2,6 +2,7 @@
 title: Release of JabRef 3.3
 id: JabRef3.3
 author: "[JabRef Developers](https://github.com/orgs/JabRef/teams/developers)"
+category: [user, developer]
 ---
 
 We are pleased to announce the release of JabRef version 3.3!

--- a/_posts/2016-04-25-WinEdtBothDirections.md
+++ b/_posts/2016-04-25-WinEdtBothDirections.md
@@ -4,6 +4,7 @@ id: JabRefWinEdt
 bg: jabref-font
 color: white
 author: "[JabRef Developers](https://github.com/orgs/JabRef/teams/developers)"
+category: user
 ---
 
 For a longtime, a single click on a toolbar button has allowed JabRef to insert citations in [WinEdt](http://www.winedt.com).

--- a/blog.css
+++ b/blog.css
@@ -30,7 +30,8 @@ h1 {
 }
 
 .section {
-  padding: 20px;
+  padding-top: 60px;
+  padding-bottom: 20px;
 }
 
 .editparagraph {

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,16 +25,22 @@ title: JabRef Blog
   <div id="main">
       
     <nav><ul>
-        <li class="p-{{ site.posts.first.id }}"><a href="#{{ site.posts.first.id }}">Top</a></li>
-        <li class="p-welcome"><a href="#welcome">JabRef Blog</a></li>
-        <li class="p-{{ site.posts.last.id }}"><a href="#{{ site.posts.last.id }}">Bottom</a></li>
+		{% for post in site.posts %}
+			{% assign all_categories = all_categories | append: post.categories | remove: ',' | remove:'/' | remove: '"' | remove: '[' | remove: ']' | append: ' ' | downcase %}
+		{% endfor %}
+		{% assign current_categories = all_categories | split: ' ' | uniq %}
+      <li class="category"><a class="absolute" href="#">all</a></li>
+		{% for current_category in current_categories %}
+			<li class="category"><a class="absolute" href="#">{{ current_category }}</a></li>
+		{% endfor %}
     </ul></nav>
     
 
     {% for page in site.posts %}
       {% capture id %}{{ page.id | remove:'/' | downcase }}{% endcapture %}
-      <div id="{{id}}" class="section p-{{id}}">
-        <div class="container {{ page.style  | default: "left" }}">
+	  {% capture category %}{{ page.categories | remove:'/' | remove: '"' | remove: '[' | remove: ']'| downcase }}{% endcapture %}
+      <div id="{{id}}" class="section p-{{id}} {{category | remove: ','}}">
+        <div class="container {{ page.style | default: 'left' }}">
             <h1>{{ page.date | date: '%B %d, %Y' }} &ndash;  {{ page.title }}</h1>
             <div class="postauthor">{{page.author | markdownify}}</div>
             {{ page.content }}

--- a/site.js
+++ b/site.js
@@ -91,5 +91,19 @@ $(document).ready(function (){
         }
 	});
 
+	$(".category a").each(function(){
+		$(this).click(function(){
+			var txt = $(this).text().toLowerCase();
+			$( ".section:not(#footer)" ).each(function() {
+				var catClass = $(this).attr("class");
+				if (txt=="all" || (catClass != null && catClass.indexOf(txt) > -1)) {
+					$(this).show();
+				} else {
+					$(this).hide();
+				}
+			});
+		});
+	});
+
 });
 


### PR DESCRIPTION
This PR is a proposal for a blogging functionallity which let's users sort the blog by the available tags as mentioned in #32 .
* Each post (.md file) needs to specify a list of tags in a tag attribute on top of the file.
* The tags of each post are read and duplicates are being removed by js.
* For all remaining tags a menu item with the tag's name will be created.
* By clicking a menu item only the posts including the menu item's name (the tag) will be shown.
The filtering will be achieved by adding the tags as classes to the sections and hiding the sections with  appropriate 'tag' classes by using jquery.

As also already mentioned in #32:
A different approach could be to use a subdirectory for each different blog. E.g. jabref.org/blog for the users blog and jabref.org/devblog for the developers blog.
