### PR TITLE
Add hacktoberfest 2019

### DIFF
--- a/GSoC2019.md
+++ b/GSoC2019.md
@@ -3,38 +3,25 @@ title: Google Summer of Code Project Ideas 2019
 layout: survey
 ---
 
-# Ideas for Google Summer of Code 2019
-
-<!--In academia, knowledge has to be manged.
-The tool [JabRef](http://www.jabref.org/) focusses on managing related work.
-It has a large user base and is the most prominent open source reference manager.
-Currently, the tool is mainly used to manage [BibTeX](https://en.wikipedia.org/wiki/BibTeX) files, which are used in [LaTeX](https://en.wikipedia.org/wiki/LaTeX) documents.
-With this GSoC project, the functionality of JabRef should be enhanced so that there is a greater user experience.
--->
+# JabRef in Google Summer of Code 2019
 
 This page lists a number of ideas for potential projects to be carried out by the students participating in Google Summer of Code 2019.
 This is by no means a closed list, so the students can feel free to propose alternative activities related to the project (the [list of feature requests](http://discourse.jabref.org/c/features) and the [GitHub issue tracker](https://github.com/JabRef/jabref/issues) might serve as an additional source of inspiration).
 Students are strongly encouraged to discuss their ideas with the developers and the community to improve their proposal until submission (e.g, using the [Gitter Channel](https://gitter.im/JabRef/jabref) or the [forum](http://discourse.jabref.org/)).
 It's also a good idea to start working on [one of the smaller issues](https://github.com/JabRef/jabref/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to make yourself familiar with [the contribution process](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md).
 
-<!--
-Since 3 years, the JabRef developers aim for increasing the code quality of JabRef.
-Having pull requests reviewed by at least two other developers, the feedback on the code is of high quality.
-The benefit for the contributor is that his Java coding skills are enhanced:
-Not only the features are evaluated, but also the architecture of the code and the code style.
-After going through that feedback, all contributors said that they learned much during contributing to JabRef.
--->
-
 ## PDF Integration
 
 * *Description:* JabRef excels at organizing and searching the metadata of bibliographic entries. Often the user is also in the possession of the full text (e.g, the article in an electronic form). Currently, these PDF documents can be linked to the corresponding bibliographic entry but are not further analyzed. It would be worthwhile to expand JabRef's feature set in this regard, for example by adding full text search, automatic extraction of metadata from a PDF, extraction of cited bibliographic entries (and linking them to entries already in the user's library) and much more. Note that the main focus in this topic is the programming the interface and not the actual search algorithms.
-* *Skills required:* Java, JavaFX (experience with Lucene and/or information retrieveal is a plus) 
+* *Skills required:* Java, JavaFX (experience with Lucene and/or information retrieveal is a plus)
 * *Expected outcome:*
-  - Integrated search interface which presents search results from attached PDF documents and/or
-  - Extraction of additional metadata and a way to display them in the user interface.
+  * Integrated search interface which presents search results from attached PDF documents and/or
+  * Extraction of additional metadata and a way to display them in the user interface.
 * *Possible mentors:* [Tobias Diez](https://github.com/tobiasdiez), [Linus Dietz](https://github.com/LinusDietz)
 
 ## LaTeX Integration
+
+This project is finished: <https://blog.jabref.org/2019/08/06/GSoC-LatexCitationsTab/>
 
 * *Description:*
   Currently, JabRef is focused on bibliographic management functionalities. However, a deeper integration with the (LaTeX) document text would be beneficial. For example, information about what references are used in which text document, how often and at which position can provide the authors with additional tools to improve theirs works.
@@ -47,17 +34,16 @@ After going through that feedback, all contributors said that they learned much 
 
 * *Description:*
   Implement a direct bibliography integration with Microsoft Word. JabRef has a deep integration with BibTeX and biblatex, but can equally be valuable for authors that prefer writing in Microsoft Word. Currently, this integration is lacking and would be highly beneficial as an Open Source alternative to existing software such as Mendeley.
-
+* *Old code* (not working): <https://github.com/JabRef/JabRef4Word>
 * *Skills required:* Java, .NET
-
 * *Expected outcome:*
   Basic integration of bibliographic functionalities such as inserting, editing, and synching bibliographic entries between Word and JabRef.
 * *Possible mentors:* [Tobias Diez](https://github.com/tobiasdiez)
 
 ## ShareLaTeX Integration
 
-* *Description*: [ShareLaTeX](https://en.wikipedia.org/wiki/ShareLaTeX) is an open source online LaTeX editor. It greatly supports researchers in collaboratively writing academic papers. ShareLaTeX, however, misses collaboratively working on bibliographic entries. This is where JabRef jumps in: Changes to the bibliographic data on ShareLaTeX should transparently be integrated in the current local JabRef database, and vice versa. This feature would complement JabRef's [support of collaboratively working using a PostgreSQL database](http://help.jabref.org/en/SQLDatabase).
-
+* *Description:* [ShareLaTeX](https://en.wikipedia.org/wiki/ShareLaTeX) is an open source online LaTeX editor. It greatly supports researchers in collaboratively writing academic papers. ShareLaTeX, however, misses collaboratively working on bibliographic entries. This is where JabRef jumps in: Changes to the bibliographic data on ShareLaTeX should transparently be integrated in the current local JabRef database, and vice versa. This feature would complement JabRef's [support of collaboratively working using a PostgreSQL database](http://help.jabref.org/en/SQLDatabase).
+* *Issue at GitHub:* Issue: <https://github.com/JabRef/jabref/issues/156>
 * *Skills required:* Java
 * *Expected outcome:* JabRef should be able to connect to a ShareLaTeX project and update bibliographic data there. Moreover, a local copy of the bibliography file has to kept updated.
 * *Possible mentors:* [Oliver Kopp](https://github.com/koppor), [Christoph](https://github.com/Siedlerchr)

--- a/_layouts/hacktoberfest.html
+++ b/_layouts/hacktoberfest.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+      body {
+        color: rgb(234, 234, 234);
+        background-color: rgb(21, 21, 21);
+      }
+      a {
+        color: rgb(99, 192, 245);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      {{ content }}
+
+      <p><a href="https://www.jabref.org">Back to homepage</a></p>
+    </div>
+  </body>
+</html>

--- a/hacktoberfest/2019.md
+++ b/hacktoberfest/2019.md
@@ -1,0 +1,58 @@
+---
+title: JabRef Hacktoberfest 2019
+layout: hacktoberfest
+---
+
+# JabRef celebrates Hacktoberfest 2019
+
+[![Hacktoberfest 2019 logo](https://hacktoberfest.digitalocean.com/assets/logo-hf19-header-8245176fe235ab5d942c7580778a914110fa06a23c3d55bf40e2d061809d8785.svg)](https://benbarth.github.io/hacktoberfest-swag/)
+
+> Get a pull request merged, get a sticker.
+>
+> Get five pull requests merged, get a T-Shirt.
+
+The tool [JabRef](https://www.jabref.org/) focusses on managing research publications.
+It has a large user base and is the most prominent open source reference manager.
+Currently, the tool is mainly used to manage [BibTeX](https://en.wikipedia.org/wiki/BibTeX) files, which are used in [LaTeX](https://en.wikipedia.org/wiki/LaTeX) documents.
+
+Since three years, the JabRef developers aim for increasing the code quality of JabRef.
+Having pull requests reviewed by at least two other developers, the feedback on the code is of high quality.
+The benefit for the contributor is that heir **Java coding skills are enhanced**:
+Not only the features are evaluated, but also the architecture of the code and the code style.
+Looking back, after going through that feedback, all former contributors said that they learned much during contributing to JabRef.
+
+After a [successful participation in Google's Summer of Code 2019](https://blog.jabref.org/2019/08/06/GSoC-LatexCitationsTab/) and giving feedback on many pull requests, we decided to take part in Hacktoberfest 2019.
+
+The JabRef team aims for high-quality code and high usability.
+Thus, just creating a pull request is not enough.
+You will get feedback on your solution with suggestions how to improve.
+to keep the pace, we ask you to quickly react on our comments.
+
+With the first accepted pull request, you will learn the rules and improve your coding skills.
+We hope that this motivates you to keep impoving JabRef and contribute to a better science.
+
+You may work on anything.
+Source for ideas:
+
+* [List of feature requests](http://discourse.jabref.org/c/features)
+* [GitHub issue tracker](https://github.com/JabRef/jabref/issues)
+* [List of GSoC 2019 projects](http://www.jabref.org/GSoC2019.html)
+* [Documentation issues](https://github.com/JabRef/help.jabref.org/issues) - good if you want to get used to the open source workflow without starting with coding.
+
+For larger contributions, contributors are encouraged to discuss their ideas with the developers and the community to improve their proposal until submission (e.g, using the [Gitter Channel](https://gitter.im/JabRef/jabref) or the [forum](http://discourse.jabref.org/)).
+It's also a good idea to start working on [one of the smaller issues](https://github.com/JabRef/jabref/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to make yourself familiar with [the contribution process](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md).
+
+**Disclaimer:**  
+Pull requests must be created in October 2019.
+We might need some days to review.
+If you create late in October, the feedback may be provided in November.
+You still have a chance to get a reward.
+In case there are seven days or more of inactivity on your side, chances are that you won't get any reward.  
+Only merged pull requests on repositories at <https://github.com/jabref/> count.
+To get a reward, you need to provide us your mailing address.
+There is no obligation on the JabRef team to send out a sticker or a T-Shirt.
+Reasons might be that we run out of stock or money.
+JabRef is maintained by a group of volunteers in their free time and not for profit.
+We do not take any liability on damages caused by you taking part in Hacktoberfest.
+
+All in all: happy hacking.


### PR DESCRIPTION
This PR adds our Hacktoberfest 2019 page.

It also updates our GSoC page to include the results.

![grafik](https://user-images.githubusercontent.com/1366654/66003847-7d0a2900-e4a7-11e9-85b3-170a11d4abaa.png)

