### PR TITLE
Redirect users to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Outdated
+*This repository for our website has been archived, and all issues are therefore frozen.*
+If you want to contribute, propose a new feature and/or report a bug with the website, please head over to the new repository https://github.com/JabRef/JabRefOnline.
+
+
 # Source of www.jabref.org
 
 > This repository contains the source of the [JabRef homepage](https://www.jabref.org/).


### PR DESCRIPTION
Part of https://github.com/JabRef/JabRefOnline/pull/1288.
After this PR is merged, all remaining issues should be transferred to JabRefOnline and then this repo here can be archived.